### PR TITLE
docs(readme): fix environment variable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,6 @@
 
 This is a simple tool to export go2rtc producer and consumer metrics to Prometheus.
 
-The path to the go2rtc API comes from `GO2RTC_PATH` environment variable or first argument. Default is `http://localhost:1984/api/streams`.
+The path to the go2rtc API comes from `GO2RTC_API_URL` environment variable or first argument. Default is `http://localhost:1984/api/streams`.
 
 Metrics port is `1985`.


### PR DESCRIPTION
The README has the wrong environment variable compared to the code.